### PR TITLE
Release v1.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - develop
 
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Latest Update: 2022/05/30
 
-Version: 1.7.1
+Version: 1.7.2
 
 [**Download**](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)
 

--- a/application/prologue.settings.json
+++ b/application/prologue.settings.json
@@ -4,7 +4,7 @@
   },
 
   "simulation": {
-    "dt": 0.001,
+    "dt": 0.0001,
     "detect_peak_threshold": 15.0,
 
     "scatter": {

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -34,7 +34,7 @@
 
   "wind_model": {
     "power_constant": 7.0, //べき法則の係数
-    "type": "real", //使用する風モデル　real, original, only_powerlow
+    "type": "real", //使用する風モデル　real, original, only_powerlow, no_wind
     "realdata_filename": "wind_data_template.csv" //風向風速データのファイル名。typeがrealの場合のみ有効。
   }
 }

--- a/src/app/AppSetting.cpp
+++ b/src/app/AppSetting.cpp
@@ -31,12 +31,14 @@ namespace AppSetting {
                 return WindModelType::Original;
             } else if (windmodeltype == "only_powerlow") {
                 return WindModelType::OnlyPowerLow;
+            } else if (windmodeltype == "no_wind") {
+                return WindModelType::NoWind;
             } else {
                 CommandLine::PrintInfo(PrintInfoType::Error,
                                        "In prologue.settings.json",
                                        "wind_model.type",
                                        ("\"" + windmodeltype + "\" is invalid string.").c_str(),
-                                       "Set \"real\", \"original\" or \"only_powerlow\"");
+                                       "Set \"real\", \"original\", \"only_powerlow\" or \"no_wind\"");
                 throw 0;
             }
         }

--- a/src/app/AppSetting.hpp
+++ b/src/app/AppSetting.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-enum class WindModelType { Real, Original, OnlyPowerLow };
+enum class WindModelType { Real, Original, OnlyPowerLow, NoWind };
 
 namespace AppSetting {
     namespace Processing {

--- a/src/dynamics/WindModel.cpp
+++ b/src/dynamics/WindModel.cpp
@@ -81,6 +81,9 @@ void WindModel::update(double height) {
     case WindModelType::OnlyPowerLow:
         m_wind = getWindOnlyPowerLow();
         break;
+    case WindModelType::NoWind:
+        m_wind = Vector3D(0, 0, 0);
+        break;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,5 +51,9 @@ void ShowSettingInfo() {
     case WindModelType::OnlyPowerLow:
         CommandLine::PrintInfo(PrintInfoType::Information, "Wind model: Only power low");
         break;
+
+    case WindModelType::NoWind:
+        CommandLine::PrintInfo(PrintInfoType::Information, "Wind model: No wind");
+        break;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "gnuplot/Gnuplot.hpp"
 #include "simulator/Simulator.hpp"
 
-const auto VERSION = "1.7.1";
+const auto VERSION = "1.7.2";
 
 void ShowSettingInfo();
 

--- a/src/simulator/Simulator.cpp
+++ b/src/simulator/Simulator.cpp
@@ -37,7 +37,8 @@ bool Simulator::initialize() {
     // settings on commandline
     setTrajectoryMode();
 
-    if (AppSetting::WindModel::type != WindModelType::Real && m_simulationMode == SimulationMode::Detail) {
+    if (m_simulationMode == SimulationMode::Detail && AppSetting::WindModel::type != WindModelType::Real
+        && AppSetting::WindModel::type != WindModelType::NoWind) {
         setWindCondition();
     }
 
@@ -75,6 +76,9 @@ bool Simulator::initialize() {
     case WindModelType::OnlyPowerLow:
         m_outputDirName += "powerlow";
         break;
+    case WindModelType::NoWind:
+        m_outputDirName += "nowind";
+        break;
     }
 
     if (AppSetting::WindModel::type != WindModelType::Real) {
@@ -99,7 +103,8 @@ bool Simulator::initialize() {
 
     m_outputDirName += "]";
 
-    if (AppSetting::WindModel::type != WindModelType::Real && m_simulationMode == SimulationMode::Detail) {
+    if (m_simulationMode == SimulationMode::Detail && AppSetting::WindModel::type != WindModelType::Real
+        && AppSetting::WindModel::type != WindModelType::NoWind) {
         std::ostringstream out;
         out.precision(2);
         out << std::fixed << m_windSpeed << "ms, " << m_windDirection << "deg";


### PR DESCRIPTION
## 機能
- 無風条件下でのシミュレーションモードを追加 #41 

## サンプル
- `prologue.settings.json` `simulation.dt`の値を0.001から0.0001へ変更 91c205311e8f396ffd2241be50017aa671f8e700
  0.001では不正確なシミュレーション結果が確認されたためより精度を向上
