### PR TITLE
べき法則の基準高度を`prologue.settings.json`で設定できるように

### DIFF
--- a/application/prologue.settings.json
+++ b/application/prologue.settings.json
@@ -16,6 +16,7 @@
 
   "wind_model": {
     "power_constant": 6.0,
+    "power_low_base_alt": 5.0,
     "type": "original",
     "realdata_filename": "sample.csv"
   }

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -34,6 +34,7 @@
 
   "wind_model": {
     "power_constant": 7.0, //べき法則の係数
+    "power_low_base_alt": 2.0, //べき法則の基準高度[m]
     "type": "real", //使用する風モデル　real, original, only_powerlow, no_wind
     "realdata_filename": "wind_data_template.csv" //風向風速データのファイル名。typeがrealの場合のみ有効。
   }

--- a/src/app/AppSetting.cpp
+++ b/src/app/AppSetting.cpp
@@ -53,6 +53,7 @@ namespace AppSetting {
     const double Simulation::windDirInterval     = Internal::InitValue<double>("simulation.scatter.wind_dir_interval");
 
     const double WindModel::powerConstant         = Internal::InitValue<double>("wind_model.power_constant");
+    const double WindModel::powerLowBaseAltitude  = Internal::InitValue<double>("wind_model.power_low_base_alt");
     const WindModelType WindModel::type           = Internal::InitWindModelType();
     const std::string WindModel::realdataFilename = Internal::InitValue<std::string>("wind_model.realdata_filename");
 }

--- a/src/app/AppSetting.hpp
+++ b/src/app/AppSetting.hpp
@@ -21,6 +21,7 @@ namespace AppSetting {
 
     namespace WindModel {
         extern const double powerConstant;
+        extern const double powerLowBaseAltitude;
         extern const WindModelType type;
         extern const std::string realdataFilename;
     }

--- a/src/dynamics/WindModel.cpp
+++ b/src/dynamics/WindModel.cpp
@@ -17,17 +17,17 @@ constexpr double tempDecayRate[N] = {-6.5e-3, 0.0, 1e-3};                       
 constexpr double basePressure[N]  = {Constant::SeaPressure, 22632.064, 5474.9};  // [Pa]
 
 // wind calculation
-constexpr double geostrophicWind    = 15;    // [m/s]
-constexpr double surfaceLayerLimit  = 300;   // [m] Surface layer -300[m]
-constexpr double ekmanLayerLimit    = 1000;  // [m] Ekman layer 300-1000[m]
-constexpr double powerLowBaseHeight = 2;     // [m]
+constexpr double geostrophicWind   = 15;    // [m/s]
+constexpr double surfaceLayerLimit = 300;   // [m] Surface layer -300[m]
+constexpr double ekmanLayerLimit   = 1000;  // [m] Ekman layer 300-1000[m]
 
 double applyPowerLow(double windSpeed, double height) {
-    return windSpeed * pow(height / powerLowBaseHeight, 1.0 / AppSetting::WindModel::powerConstant);
+    return windSpeed
+           * pow(height / AppSetting::WindModel::powerLowBaseAltitude, 1.0 / AppSetting::WindModel::powerConstant);
 }
 
 Vector3D applyPowerLow(const Vector3D& wind, double height) {
-    return wind * pow(height / powerLowBaseHeight, 1.0 / AppSetting::WindModel::powerConstant);
+    return wind * pow(height / AppSetting::WindModel::powerLowBaseAltitude, 1.0 / AppSetting::WindModel::powerConstant);
 }
 
 WindModel::WindModel(double groundWindSpeed, double groundWindDirection, double magneticDeclination) :


### PR DESCRIPTION
close #46 

- ドキュメント更新
- `prologue.settings.json`を更新
- 以前まで基準が2.0mだったものを、サンプルで基準5.0mに変更