### PR TITLE
磁気偏角を諸元から設定できるように

### DIFF
--- a/application/input/json/spec_multi.json
+++ b/application/input/json/spec_multi.json
@@ -55,6 +55,7 @@
 
   "environment": {
     "place": "nosiro_sea",
+    "magnetic_declination": null,
     "rail_len": 5.0,
     "rail_azi": -60.0,
     "rail_elev": 70

--- a/application/input/json/spec_single.json
+++ b/application/input/json/spec_single.json
@@ -22,6 +22,7 @@
 
   "environment": {
     "place": "nosiro_sea",
+    "magnetic_declination": null,
     "rail_len": 5.0,
     "rail_azi": -60.0,
     "rail_elev": 70

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -85,6 +85,7 @@
 
 	"environment": {
 		"place": "マップ名称: nosiro_sea nosiro_land izu_sea izu_land",
+		"magnetic_declination": "磁気偏角[deg] nullまたは数値（nullの場合はマップごとのデフォルト値を使用 DYNAMICS.md参照）"
 		"rail_len": "ランチャレール長[m]",
 		"rail_azi": "ランチャ方位角[degree]　北から右回り",
 		"rail_elev": "ランチャ迎角[degree]"

--- a/src/env/Environment.cpp
+++ b/src/env/Environment.cpp
@@ -8,8 +8,9 @@ void Environment::initialize(const std::string& filename) {
     boost::property_tree::ptree pt;
     boost::property_tree::read_json("input/json/" + filename, pt);
 
-    place         = JsonUtils::GetValue<std::string>(pt, "environment.place");
-    railLength    = JsonUtils::GetValueExc<double>(pt, "environment.rail_len");
-    railAzimuth   = JsonUtils::GetValueExc<double>(pt, "environment.rail_azi");
-    railElevation = JsonUtils::GetValueExc<double>(pt, "environment.rail_elev");
+    place               = JsonUtils::GetValue<std::string>(pt, "environment.place");
+    magneticDeclination = JsonUtils::GetOptional<double>(pt, "environment.magnetic_declination");
+    railLength          = JsonUtils::GetValueExc<double>(pt, "environment.rail_len");
+    railAzimuth         = JsonUtils::GetValueExc<double>(pt, "environment.rail_azi");
+    railElevation       = JsonUtils::GetValueExc<double>(pt, "environment.rail_elev");
 }

--- a/src/env/Environment.hpp
+++ b/src/env/Environment.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 struct Environment {
     std::string place;
+    std::optional<double> magneticDeclination;
     double railLength;
     double railAzimuth;
     double railElevation;

--- a/src/simulator/Simulator.cpp
+++ b/src/simulator/Simulator.cpp
@@ -119,16 +119,28 @@ bool Simulator::run() {
 
     // Set map
     {
-        auto place = m_environment.place;
+        // Get / Set place
+        std::string place = m_environment.place;
         std::transform(
             place.begin(), place.end(), place.begin(), [](int c) { return static_cast<char>(::tolower(c)); });
         if (const auto map = Map::GetMap(place); map.has_value()) {
             m_mapData = map.value();
-            Gnuplot::Initialize(m_outputDirName.c_str(), m_mapData);
         } else {
             CommandLine::PrintInfo(PrintInfoType::Error, "This map is invalid.");
             return false;
         }
+
+        // Set magnetic declination if need
+        if (m_environment.magneticDeclination.has_value()) {
+            CommandLine::PrintInfo(PrintInfoType::Information,
+                                   ("Magnetic declination is set to "
+                                    + std::to_string(m_environment.magneticDeclination.value()) + "[deg] by json")
+                                       .c_str());
+            m_mapData.magneticDeclination = m_environment.magneticDeclination.value();
+        }
+
+        // Initialize gnuplot by the map
+        Gnuplot::Initialize(m_outputDirName.c_str(), m_mapData);
     }
 
     // Simulate

--- a/src/utils/JsonUtils.hpp
+++ b/src/utils/JsonUtils.hpp
@@ -18,10 +18,19 @@ namespace JsonUtils {
 
     template <typename T>
     T GetValue(const boost::property_tree::ptree& pt, const std::string& key) {
-        if (boost::optional<T> value = pt.get_optional<T>(key)) {
+        if (const boost::optional<T> value = pt.get_optional<T>(key)) {
             return value.get();
         }
         return T();
+    }
+
+    template <typename T>
+    std::optional<T> GetOptional(const boost::property_tree::ptree& pt, const std::string& key) {
+        if (const auto result = pt.get_optional<T>(key); result.has_value()) {
+            return result.value();
+        } else {
+            return std::nullopt;
+        }
     }
 
     template <typename T>


### PR DESCRIPTION
close #38 

諸元JSONファイルに `environment.magnetic_declination`を追加。`null` または数値を指定できる。
`null`の場合、磁気偏角は[DYNAMICS.md](https://github.com/FROM-THE-EARTH/Prologue/blob/main/docs/DYNAMICS.md#%E7%A3%81%E6%B0%97%E5%81%8F%E8%A7%92)にある値に自動的に設定され、数値の場合はその値が磁気偏角として設定される。