### PR TITLE
Release v1.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Download
 
-Latest Update: 2022/06/04
+Latest Update: 2022/06/08
 
-Version: 1.8.3
+Version: 1.8.4
 
 [**Download**](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Latest Update: 2022/06/04
 
-Version: 1.8.2
+Version: 1.8.3
 
 [**Download**](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)
 

--- a/application/prologue.settings.json
+++ b/application/prologue.settings.json
@@ -8,7 +8,7 @@
     "detect_peak_threshold": 15.0,
 
     "scatter": {
-      "wind_speed_min": 0.0,
+      "wind_speed_min": 1.0,
       "wind_speed_max": 7.0,
       "wind_dir_interval": 22.5
     }

--- a/application/prologue.settings.json
+++ b/application/prologue.settings.json
@@ -1,6 +1,7 @@
 {
   "processing": {
-    "multi_thread": true
+    "multi_thread": true,
+    "multi_thread_count": 4
   },
 
   "simulation": {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -43,11 +43,12 @@ MSVC, GCC, Clang などのコンパイラが入っていない場合はインス
 
 1. ソースコードの修正が完了し、更新準備が整う
 2. `main.cpp`の`const auto VERSION = "X.X.X"` を書き換える
-3. [`README.md`](https://github.com/FROM-THE-EARTH/Prologue/blob/main/README.md)のバージョン・日付・更新履歴を修正する
+3. [`README.md`](https://github.com/FROM-THE-EARTH/Prologue/blob/main/README.md)のバージョン・日付を修正する
 4. 上記作業が終了したコミットに`vX.X.X`とタグをつけ、リモートにプッシュする（例 `v1.2.3`）
    タグを付けたコミットに不具合があり、バージョンを変更せずにリリース作業をやり直す場合、不具合を修正したコミットに`vX.X.X.X`とタグを付けリモートにプッシュする（例 `v1.2.3.1`, `v1.2.3.2`）
 5. [**Actions**] タグに反応して[`release.yml`](https://github.com/FROM-THE-EARTH/Prologue/blob/main/.github/workflows/release.yml)のワークフローが実行される
 6. [**Actions**] [Releases](https://github.com/FROM-THE-EARTH/Prologue/releases) に`vX.X.X`を名前として Windows, macOS, Linux 向けの実行ファイル・設定ファイル・入力ファイルを同包した zip ファイルが登録される
+7. Releases に更新情報を書く
 
 ## CI
 

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -19,6 +19,7 @@
 {
   "processing": {
     "multi_thread": false // マルチスレッドによる処理の高速化。Scatterモードでのみ有効。
+    "multi_thread_count": 4 // スレッド数
   },
 
   "simulation": {

--- a/src/app/AppSetting.cpp
+++ b/src/app/AppSetting.cpp
@@ -3,6 +3,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <iostream>
+#include <thread>
 
 #include "CommandLine.hpp"
 #include "utils/JsonUtils.hpp"
@@ -20,6 +21,35 @@ namespace AppSetting {
             }
 
             return JsonUtils::GetValueExc<T>(pt, key);
+        }
+
+        size_t InitThreadCount() {
+            const int count = Internal::InitValue<int>("processing.multi_thread_count");
+            if (count < 1) {
+                CommandLine::PrintInfo(PrintInfoType::Warning,
+                                       "Specified thread count is too low",
+                                       "Thread count is automatically set to 1.");
+                return 1;
+            }
+
+            const size_t threadCountLimit = std::thread::hardware_concurrency();
+            if (threadCountLimit == 0) {
+                CommandLine::PrintInfo(PrintInfoType::Error,
+                                       "Could not get hardware concurrency",
+                                       "Thread count is automatically set to 1.");
+                return 1;
+            }
+
+            if (static_cast<size_t>(count) > threadCountLimit) {
+                CommandLine::PrintInfo(
+                    PrintInfoType::Warning,
+                    "Specified thread count exceeds the number that the machine can run.",
+                    (std::string("Thread count is automatically set to ") + std::to_string(threadCountLimit) + ".")
+                        .c_str());
+                return threadCountLimit;
+            }
+
+            return static_cast<size_t>(count);
         }
 
         WindModelType InitWindModelType() {
@@ -54,7 +84,8 @@ namespace AppSetting {
         }
     }
 
-    const bool Processing::multiThread = Internal::InitValue<bool>("processing.multi_thread");
+    const bool Processing::multiThread   = Internal::InitValue<bool>("processing.multi_thread");
+    const size_t Processing::threadCount = Internal::InitThreadCount();
 
     const double Simulation::dt                  = Internal::InitValue<double>("simulation.dt");
     const double Simulation::detectPeakThreshold = Internal::InitValue<double>("simulation.detect_peak_threshold");

--- a/src/app/AppSetting.cpp
+++ b/src/app/AppSetting.cpp
@@ -44,8 +44,7 @@ namespace AppSetting {
                 CommandLine::PrintInfo(
                     PrintInfoType::Warning,
                     "Specified thread count exceeds the number that the machine can run.",
-                    (std::string("Thread count is automatically set to ") + std::to_string(threadCountLimit) + ".")
-                        .c_str());
+                    "Thread count is automatically set to " + std::to_string(threadCountLimit) + ".");
                 return threadCountLimit;
             }
 
@@ -67,7 +66,7 @@ namespace AppSetting {
                 CommandLine::PrintInfo(PrintInfoType::Error,
                                        "In prologue.settings.json",
                                        "wind_model.type",
-                                       ("\"" + windmodeltype + "\" is invalid string.").c_str(),
+                                       "\"" + windmodeltype + "\" is invalid string.",
                                        "Set \"real\", \"original\", \"only_powerlow\" or \"no_wind\"");
                 throw 0;
             }

--- a/src/app/AppSetting.hpp
+++ b/src/app/AppSetting.hpp
@@ -7,6 +7,7 @@ enum class WindModelType { Real, Original, OnlyPowerLow, NoWind };
 namespace AppSetting {
     namespace Processing {
         extern const bool multiThread;
+        extern const size_t threadCount;
     }
 
     namespace Simulation {

--- a/src/app/CommandLine.hpp
+++ b/src/app/CommandLine.hpp
@@ -14,8 +14,8 @@ namespace CommandLine {
 
         void PrintInfoLines();
 
-        template <class... Args>
-        void ShowChoices(const char* s, Args... choices) {
+        template <typename T, class... Args>
+        void ShowChoices(const T& s, Args... choices) {
             std::cout << Counter << ": " << s << std::endl;
 
             Counter++;
@@ -23,15 +23,15 @@ namespace CommandLine {
             ShowChoices(std::forward<Args>(choices)...);
         }
 
-        template <class... Args>
-        void PrintInfoLines(const char* line, Args... lines) {
+        template <typename T, class... Args>
+        void PrintInfoLines(const T& line, Args... lines) {
             std::cout << "   " << line << std::endl;
 
             PrintInfoLines(std::forward<Args>(lines)...);
         }
 
-        template <class... Args>
-        void PrintInfoFirstLine(PrintInfoType type, const char* line, Args... lines) {
+        template <typename T, class... Args>
+        void PrintInfoFirstLine(PrintInfoType type, const T& line, Args... lines) {
             switch (type) {
             case PrintInfoType::Information:
                 std::cout << "I: ";
@@ -52,8 +52,8 @@ namespace CommandLine {
         }
     }
 
-    template <class... Args>
-    void Question(const char* question, Args... choices) {
+    template <typename T, class... Args>
+    void Question(const T& question, Args... choices) {
         std::cout << "<!===" << question << "===!>" << std::endl;
 
         Internal::Counter = 1;

--- a/src/gnuplot/Gnuplot.cpp
+++ b/src/gnuplot/Gnuplot.cpp
@@ -7,21 +7,16 @@
 
 #include "app/CommandLine.hpp"
 #include "env/Map.hpp"
+#include "misc/Platform.hpp"
 #include "solver/Solver.hpp"
 
-#if defined(_WIN32) || defined(WIN32)
-#define POPEN _popen
-#define PCLOSE _pclose
+#if PLATFORM_WINDOWS
 #define GNUPLOT_TERMINAL "windows"
 #define PAUSE_COMMAND "pause"
-#elif __APPLE__
-#define POPEN popen
-#define PCLOSE pclose
+#elif PLATFORM_MACOS
 #define GNUPLOT_TERMINAL "qt"
 #define PAUSE_COMMAND "read -n1 -r -p \"Press any key to continue...\" key"
 #else
-#define POPEN popen
-#define PCLOSE pclose
 #define GNUPLOT_TERMINAL "x11"
 #define PAUSE_COMMAND "read -rsp $'Press any key to continue...\n'"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,10 +40,10 @@ int main() {
 
 void ShowSettingInfo() {
     // Wind model
-    const std::string s = "Wind data file: " + AppSetting::WindModel::realdataFilename;
+    const std::string windFile = "Wind data file: " + AppSetting::WindModel::realdataFilename;
     switch (AppSetting::WindModel::type) {
     case WindModelType::Real:
-        CommandLine::PrintInfo(PrintInfoType::Information, "Wind model: Real", s.c_str(), "Run detail mode simulation");
+        CommandLine::PrintInfo(PrintInfoType::Information, "Wind model: Real", windFile, "Run detail mode simulation");
         break;
 
     case WindModelType::Original:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "gnuplot/Gnuplot.hpp"
 #include "simulator/Simulator.hpp"
 
-const auto VERSION = "1.8.3";
+const auto VERSION = "1.8.4";
 
 void ShowSettingInfo();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "gnuplot/Gnuplot.hpp"
 #include "simulator/Simulator.hpp"
 
-const auto VERSION = "1.8.2";
+const auto VERSION = "1.8.3";
 
 void ShowSettingInfo();
 

--- a/src/misc/Platform.hpp
+++ b/src/misc/Platform.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+// Macros to check which platform compiling on
+#if defined(_WIN32) || defined(WIN32)
+#define PLATFORM_WINDOWS 1
+#else
+#define PLATFORM_WINDOWS 0
+#endif
+
+#define PLATFORM_MACOS __APPLE__
+
+// popen / pclose definition
+#if PLATFORM_WINDOWS
+#define POPEN _popen
+#define PCLOSE _pclose
+#else
+#define POPEN popen
+#define PCLOSE pclose
+#endif

--- a/src/result/ResultSaver.cpp
+++ b/src/result/ResultSaver.cpp
@@ -42,6 +42,8 @@ namespace ResultSaver {
         "altitude[m]",
         "velocity[m/s]",
         "airspeed[m/s]",
+        "accel[m/s2]",
+        "longitudinal accel[m/s2]",
         "normal_force[N]",
         "Cnp",
         "Cny",
@@ -99,6 +101,8 @@ namespace ResultSaver {
                      << WITH_COMMA(step.rocket_ix) << WITH_COMMA(step.rocket_attackAngle)
                      << WITH_COMMA(step.rocket_pos.z) << WITH_COMMA(step.rocket_velocity.length())
                      << WITH_COMMA(step.rocket_airspeed_b.length())
+                     << WITH_COMMA(step.rocket_force_b.length() / step.rocket_mass)
+                     << WITH_COMMA(step.rocket_force_b.x / step.rocket_mass)
                      << WITH_COMMA(sqrt(step.rocket_force_b.y * step.rocket_force_b.y
                                         + step.rocket_force_b.z * step.rocket_force_b.z))
                      << WITH_COMMA(step.Cnp) << WITH_COMMA(step.Cny) << WITH_COMMA(step.Cmqp) << WITH_COMMA(step.Cmqy)

--- a/src/result/ResultSaver.cpp
+++ b/src/result/ResultSaver.cpp
@@ -6,13 +6,8 @@
 
 #include "app/AppSetting.hpp"
 #include "app/CommandLine.hpp"
+#include "misc/Platform.hpp"
 #include "solver/Solver.hpp"
-
-#if defined(_WIN32) || defined(WIN32)
-#define SPRINTF sprintf_s
-#else
-#define SPRINTF snprintf
-#endif
 
 #define WITH_COMMA(value) value << ','
 

--- a/src/rocket/RocketSpec.cpp
+++ b/src/rocket/RocketSpec.cpp
@@ -46,7 +46,7 @@ void RocketSpec::setRocketParam(const boost::property_tree::ptree& pt, size_t in
     if (param.parachute[0].terminalVelocity == 0.0) {
         m_existInfCd = true;
         CommandLine::PrintInfo(PrintInfoType::Warning,
-                               (std::string("Rocket: ") + key).c_str(),
+                               "Rocket: " + key,
                                "Terminal velocity is undefined.",
                                "Parachute Cd value is automatically calculated.");
     } else {
@@ -56,11 +56,9 @@ void RocketSpec::setRocketParam(const boost::property_tree::ptree& pt, size_t in
     param.engine.loadThrustData(JsonUtils::GetValue<std::string>(pt, key + ".motor_file"));
     param.aeroCoefStorage.init(JsonUtils::GetValue<std::string>(pt, key + ".aero_coef_file"));
     if (param.aeroCoefStorage.isTimeSeriesSpec()) {
-        CommandLine::PrintInfo(
-            PrintInfoType::Information, ("Rocket: " + key).c_str(), "Aero coefficients are set from CSV");
+        CommandLine::PrintInfo(PrintInfoType::Information, "Rocket: " + key, "Aero coefficients are set from CSV");
     } else {
-        CommandLine::PrintInfo(
-            PrintInfoType::Information, ("Rocket: " + key).c_str(), "Aero coefficients are set from JSON");
+        CommandLine::PrintInfo(PrintInfoType::Information, "Rocket: " + key, "Aero coefficients are set from JSON");
         param.aeroCoefStorage.init(JsonUtils::GetValueExc<double>(pt, key + ".CPlen"),
                                    JsonUtils::GetValue<double>(pt, key + ".CP_alpha"),
                                    JsonUtils::GetValueExc<double>(pt, key + ".Cd_i"),

--- a/src/simulator/ScatterSimulator.cpp
+++ b/src/simulator/ScatterSimulator.cpp
@@ -65,7 +65,6 @@ bool ScatterSimulator::launchNextAsyncSolve(AsyncSolver& solver) {
 }
 
 bool ScatterSimulator::multiThreadSimulation() {
-    const size_t threadCount = 2;
     const size_t simulationCount =
         static_cast<size_t>(std::ceil(360 / AppSetting::Simulation::windDirInterval)
                             * (AppSetting::Simulation::windSpeedMax - AppSetting::Simulation::windSpeedMin + 1));
@@ -73,13 +72,13 @@ bool ScatterSimulator::multiThreadSimulation() {
     bool simulationFinished = false;
     size_t indexCounter     = 0;
 
-    std::vector<AsyncSolver> solvers(threadCount);
-    std::vector<size_t> threadTargetIndexes(threadCount);
+    std::vector<AsyncSolver> solvers(AppSetting::Processing::threadCount);
+    std::vector<size_t> threadTargetIndexes(AppSetting::Processing::threadCount);
 
     m_result.resize(simulationCount);
 
     // Launch initial solves
-    for (size_t i = 0; i < threadCount; i++) {
+    for (size_t i = 0; i < AppSetting::Processing::threadCount; i++) {
         if (!simulationFinished) {
             simulationFinished     = !launchNextAsyncSolve(solvers[i]);
             threadTargetIndexes[i] = indexCounter++;
@@ -88,7 +87,7 @@ bool ScatterSimulator::multiThreadSimulation() {
 
     while (true) {
         if (!simulationFinished) {
-            for (size_t i = 0; i < threadCount; i++) {
+            for (size_t i = 0; i < AppSetting::Processing::threadCount; i++) {
                 // If solvers[i].thread is ready to get the result, get it and solve next
                 if (!simulationFinished && isFutureReady(solvers[i])) {
                     m_result[threadTargetIndexes[i]] = solvers[i].get()->getResultScatterFormat();
@@ -99,7 +98,7 @@ bool ScatterSimulator::multiThreadSimulation() {
         }
         // Get results and end simulation
         else {
-            for (size_t i = 0; i < threadCount; i++) {
+            for (size_t i = 0; i < AppSetting::Processing::threadCount; i++) {
                 // Wait for simulations to finish and get results
                 m_result[threadTargetIndexes[i]] = solvers[i].get()->getResultScatterFormat();
             }

--- a/src/simulator/ScatterSimulator.hpp
+++ b/src/simulator/ScatterSimulator.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <future>
+
 #include "Simulator.hpp"
 #include "gnuplot/Gnuplot.hpp"
 
 class ScatterSimulator : public Simulator {
+    using AsyncSolver = std::future<std::shared_ptr<SimuResultLogger>>;
+
 private:
     std::vector<SimuResultSummary> m_result;
 
@@ -17,11 +21,15 @@ public:
     void plotToGnuplot() override;
 
 private:
-    void solve(double windSpeed, double windDir, std::shared_ptr<SimuResultLogger>& resultLogger, bool* finish, bool* error);
+    std::shared_ptr<SimuResultLogger> solve(double windSpeed, double windDir);
 
     bool singleThreadSimulation();
 
     bool multiThreadSimulation();
 
     bool updateWindCondition();
+
+    // Launch thread to solve and update wind condition
+    // Return false if this is last solve
+    bool launchNextAsyncSolve(AsyncSolver& solver);
 };

--- a/src/simulator/Simulator.cpp
+++ b/src/simulator/Simulator.cpp
@@ -133,9 +133,8 @@ bool Simulator::run() {
         // Set magnetic declination if need
         if (m_environment.magneticDeclination.has_value()) {
             CommandLine::PrintInfo(PrintInfoType::Information,
-                                   ("Magnetic declination is set to "
-                                    + std::to_string(m_environment.magneticDeclination.value()) + "[deg] by json")
-                                       .c_str());
+                                   "Magnetic declination is set to "
+                                       + std::to_string(m_environment.magneticDeclination.value()) + "[deg] by json");
             m_mapData.magneticDeclination = m_environment.magneticDeclination.value();
         }
 
@@ -151,10 +150,10 @@ bool Simulator::run() {
             return false;
         }
 
-        const auto end      = std::chrono::system_clock::now();
-        const auto elapsed  = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-        const std::string s = "Finish processing: " + std::to_string(elapsed / 1000000.0) + "[s]";
-        CommandLine::PrintInfo(PrintInfoType::Information, s.c_str());
+        const auto end     = std::chrono::system_clock::now();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+        CommandLine::PrintInfo(PrintInfoType::Information,
+                               "Finish processing: " + std::to_string(elapsed / 1000000.0) + "[s]");
     }
 
     // Save result and init commandline
@@ -163,8 +162,7 @@ bool Simulator::run() {
 
         saveResult();
 
-        const std::string str = "Result is saved in \"" + m_outputDirName + "/\"";
-        CommandLine::PrintInfo(PrintInfoType::Information, str.c_str());
+        CommandLine::PrintInfo(PrintInfoType::Information, "Result is saved in \"" + m_outputDirName + "/\"");
 
         CommandLine::SetOutputDir(m_outputDirName);
     }

--- a/src/utils/JsonUtils.hpp
+++ b/src/utils/JsonUtils.hpp
@@ -54,7 +54,7 @@ namespace JsonUtils {
     template <typename T>
     T GetValueExc(const boost::property_tree::ptree& pt, const std::string& key) {
         if (!JsonUtils::HasValue<T>(pt, key)) {
-            CommandLine::PrintInfo(PrintInfoType::Error, ("The key of " + key + " has no value.").c_str());
+            CommandLine::PrintInfo(PrintInfoType::Error, "The key of " + key + " has no value.");
             throw 0;
         }
 


### PR DESCRIPTION
## 機能
- `prologue.settings.json` `processing.multi_thread_count`でScatterシミュレーション、マルチスレッド時のスレッド数を指定可能に 1422a959a1a996a9d9d6c1c386242fae7461ddd5
  - デフォルト値は４です。（今までは２で固定）
  - 値が小さすぎる場合、スレッド数は１に設定されます。
  - 値が大きすぎる場合、スレッド数は実行中のマシンで実行可能な最大のスレッド数に設定されます。

## その他
- Scatterシミュレーション、マルチスレッド時の解析時間を高速化 15611b019eb1716172d5579cb870208f4d81bb58
- `prologue.settings.json` `simulation.scatter.wind_speed_min`のデフォルト値を１に変更 6096dd7ba9c15e4621580f68c59506941e286f55