### PR TITLE
シミュレーション実行後に結果フォルダを開く `--open-result` オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Version: 1.9.1
 - `--no-save`: 結果を保存しない
 - `--no-plot`: 結果をプロットしない
 - `--dry-run`: 結果を保存もプロットしない（`--no-save --no-plot`と同値）
+- `--open-result`: シミュレーション実行後に結果のフォルダをエクスプローラーなどで開く
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Version: 1.9.1
 
 ## 利用方法
 
-1. Gnuplot を導入
+1. 事前準備
    - Gnuplot の導入
       - **Windows**: [ここ](https://sourceforge.net/projects/gnuplot/files/gnuplot/5.2.8/)からインストール<br>
       gnuplot のデフォルト出力形式の選択で **wxt** を選択
@@ -30,16 +30,14 @@ Version: 1.9.1
          sudo mkdir -p /var/lib/samba/usershares
          ```
 
-2. [**ダウンロード**](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)した Prologue の zip ファイルを展開
+2. [ダウンロード](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)した Prologue の zip ファイルを展開
 
 3. [各パラメータの入力形式](https://github.com/FROM-THE-EARTH/Prologue/blob/master/docs/INPUT.md)に沿ってファイルを作成する
 
-4. `Prologue` を起動<br>
+4. Prologue を起動、指示に従ってシミュレーションを実行<br>
    macOS, Linux の場合はターミナル上でのみ実行可能
 
-5. 指示に従ってシミュレーションを実行
-
-6. `result/` フォルダ下に結果が格納される
+5. `result/` フォルダ下に結果が格納される
 
 ## コマンドラインオプション
 ターミナルで実行時、`./Prologue --command`のようにして以下のオプションを指定できます。

--- a/README.md
+++ b/README.md
@@ -15,13 +15,22 @@ Version: 1.9.1
 ## 利用方法
 
 1. Gnuplot を導入
+   - Gnuplot の導入
+      - **Windows**: [ここ](https://sourceforge.net/projects/gnuplot/files/gnuplot/5.2.8/)からインストール<br>
+      gnuplot のデフォルト出力形式の選択で **wxt** を選択
 
-   - **Windows**: [ここ](https://sourceforge.net/projects/gnuplot/files/gnuplot/5.2.8/)からインストール<br>
-     gnuplot のデフォルト出力形式の選択で **wxt** を選択する
-   - **macOS**: [Homebrew](https://brew.sh/index_ja)をインストール後、ターミナルで `brew install gnuplot`
-   - **Linux**: ターミナルで `sudo apt install gnuplot`
+      - **macOS**: [Homebrew](https://brew.sh/index_ja)をインストール後、ターミナルで `brew install gnuplot`
+      
+      - **Linux**: ターミナルで `sudo apt install gnuplot`
 
-2. ダウンロードした zip ファイルを展開
+   - その他
+      - **Linux**: `--open-result` オプション指定時にエラーが発生する場合があるため以下を実行
+         ```sh
+         sudo apt install samba-common-bin
+         sudo mkdir -p /var/lib/samba/usershares
+         ```
+
+2. [**ダウンロード**](https://github.com/FROM-THE-EARTH/Prologue/releases/latest)した Prologue の zip ファイルを展開
 
 3. [各パラメータの入力形式](https://github.com/FROM-THE-EARTH/Prologue/blob/master/docs/INPUT.md)に沿ってファイルを作成する
 

--- a/src/app/Option.cpp
+++ b/src/app/Option.cpp
@@ -20,6 +20,8 @@ namespace CommandLineOption {
                 option.plotResult = false;
             } else if (opt == "--dry-run") {
                 option.dryRun = true;
+            } else if (opt == "--open-result") {
+                option.openResultFolder = true;
             }
         }
 

--- a/src/app/Option.hpp
+++ b/src/app/Option.hpp
@@ -14,6 +14,9 @@ namespace CommandLineOption {
 
         // false: Neither save nor plot
         bool dryRun = false;
+
+        // Whether to open result folder automatically
+        bool openResultFolder = false;
     };
 
     Option ParseArgs(int argc, char* argv[]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
 #elif PLATFORM_MACOS
         system(("open " + path.string()).c_str());
 #else
-        system(("nautilus " + path.string()).c_str());
+        system(("nautilus -w \"" + path.string() + "\" &").c_str());
 #endif
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 // int main()を含む、プログラムの開始関数
 // ------------------------------------------------
 
+#include <filesystem>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -9,6 +10,7 @@
 #include "app/AppSetting.hpp"
 #include "app/CommandLine.hpp"
 #include "app/Option.hpp"
+#include "misc/Platform.hpp"
 #include "simulator/SimulatorFactory.hpp"
 
 const auto VERSION = "1.9.1";
@@ -46,6 +48,18 @@ int main(int argc, char* argv[]) {
     if (option.plotResult && !option.dryRun) {
         CommandLine::PrintInfo(PrintInfoType::Information, "Plotting result...");
         simulator->plotToGnuplot();
+    }
+
+    // 結果フォルダを開く
+    if (option.openResultFolder) {
+        const auto path = std::filesystem::current_path() / "result" / simulator->getOutputDirectory();
+#if PLATFORM_WINDOWS
+        system(("explorer " + path.string()).c_str());
+#elif PLATFORM_MACOS
+        system(("open " + path.string()).c_str());
+#else
+        system(("nautilus " + path.string()).c_str());
+#endif
     }
 
     return 0;

--- a/src/simulator/SimulatorBase.hpp
+++ b/src/simulator/SimulatorBase.hpp
@@ -55,6 +55,10 @@ public:
     // シミュレーション実行
     bool run(bool output);
 
+    std::string getOutputDirectory() const {
+        return m_outputDirName;
+    }
+
 protected:
     virtual bool simulate() = 0;
 


### PR DESCRIPTION
close #94 