### PR TITLE
Implement latest version notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(
 set(SOURCE_FILES
 	"src/app/AppSetting.cpp"
 	"src/app/CommandLine.cpp"
+	"src/app/FetchVersion.cpp"
 	"src/app/Option.cpp"
 
 	"src/dynamics/WindModel.cpp"

--- a/src/app/FetchVersion.cpp
+++ b/src/app/FetchVersion.cpp
@@ -1,0 +1,60 @@
+﻿// ------------------------------------------------
+// FetchVersion.hppの実装
+// ------------------------------------------------
+
+#include "FetchVersion.hpp"
+
+#include <iostream>
+#include <memory>
+#include <array>
+#include <string>
+#include <stdexcept>
+
+#include "app/CommandLine.hpp"
+#include "misc/Platform.hpp"
+
+
+const std::string PROLOGUE_LATEST_URL = "https://github.com/FROM-THE-EARTH/Prologue/releases/latest";
+const int MAX_REDIRECTS = 5;
+
+namespace FetchVersion {
+	std::string GetLatestVersionString(){
+		std::string cmd;
+		// redirect device is different between Windows and Mac/Linux systems
+		if (PLATFORM_WINDOWS)
+			cmd = "curl -sL -o nul -w \"%{url_effective}\" \"" + PROLOGUE_LATEST_URL + "\"";
+		else
+			cmd = "curl -sL -o /dev/null -w \"%{url_effective}\" \"" + PROLOGUE_LATEST_URL + "\"";
+
+		std::array<char, 4096> buf{};
+		std::string result;
+
+		FILE* pipe = POPEN(cmd.c_str(), "r");
+		if (!pipe) {
+			CommandLine::PrintInfo(PrintInfoType::Warning, "Failed to check latest version.");
+			return "N/A";
+		}
+		while (fgets(buf.data(), static_cast<int>(buf.size()), pipe)) {
+			result += buf.data();
+		}
+
+		int rc = PCLOSE(pipe);
+		if (rc != 0 || result.empty()) {
+			CommandLine::PrintInfo(PrintInfoType::Warning, "Failed to check latest version.");
+			return "N/A";
+		}
+
+		// trim newline characters
+		while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) result.pop_back();
+
+		// Extract version from URL
+		size_t pos = result.find_last_of('/');
+		if (pos != std::string::npos && pos + 1 < result.size())
+			result = result.substr(pos + 2);
+		else
+			result = "N/A";
+
+
+		return result;
+	}
+}

--- a/src/app/FetchVersion.hpp
+++ b/src/app/FetchVersion.hpp
@@ -1,0 +1,11 @@
+// ------------------------------------------------
+// バージョンを取得・表示するためのインターフェース
+// ------------------------------------------------
+
+#pragma once
+
+#include <string>
+
+namespace FetchVersion {
+	std::string GetLatestVersionString();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,16 +9,28 @@
 
 #include "app/AppSetting.hpp"
 #include "app/CommandLine.hpp"
+#include "app/FetchVersion.hpp"
 #include "app/Option.hpp"
 #include "misc/Platform.hpp"
 #include "simulator/SimulatorFactory.hpp"
 
-const auto VERSION = "1.9.11";
+const auto VERSION = "1.9.1";
 
 void ShowSettingInfo();
 
 int main(int argc, char* argv[]) {
     std::cout << "Prologue v" << VERSION << std::endl;
+
+    const auto latest_version = FetchVersion::GetLatestVersionString();
+	if (latest_version != "N/A" && latest_version != VERSION) {
+		CommandLine::PrintInfo(PrintInfoType::Information,
+			"A newer version of Prologue is available: v" + latest_version + "."
+		);
+		CommandLine::PrintInfo(PrintInfoType::Information,
+			"Please visit https://github.com/FROM-THE-EARTH/Prologue/releases/latest for more information."
+		);
+	}
+
 
     const auto option = CommandLineOption::ParseArgs(argc, argv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@
 #include "misc/Platform.hpp"
 #include "simulator/SimulatorFactory.hpp"
 
-const auto VERSION = "1.9.1";
+const auto VERSION = "1.9.11";
 
 void ShowSettingInfo();
 


### PR DESCRIPTION
curlを使った最新版リリース通知を実装 #39 
[Windows10/11にもcurlが標準搭載されている](https://curl.se/windows/microsoft.html)ので、基本任意の環境で動く
(windows10の場合はバージョン1803 (2018年3月) 以降ならインストールされているらしい ([Stack Overflow](https://stackoverflow.com/questions/9507353/how-do-i-install-and-use-curl-on-windows)))